### PR TITLE
another worlds

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -1,7 +1,7 @@
 ---
 slug: :mikutter_hikitori
 depends:
-  mikutter: 0.2.2.1264
+  mikutter: '3.9.0'
   plugin: []
 version: '1.0'
 author: jk443

--- a/mikutter_hikitori.rb
+++ b/mikutter_hikitori.rb
@@ -4,21 +4,20 @@ Plugin.create(:mikutter_hikitori) do
   command(
           :mikutter_hikitori,
           name: '息を引き取るプラグイン',
-          condition: lambda{ |opt| true },
+          condition: -> opt { compose?(opt.world, opt.messages[0]) },
           visible: true,
           role: :timeline
           ) do |opt|
     to_name = opt.messages[0].user.idname
     msg = "そう言うと"
-    msg = msg + "@"+to_name
-    msg = msg + "は静かに息を引き取った．"
+    msg = msg + " @"+to_name
+    msg = msg + " は静かに息を引き取った．"
     msg = msg + "誰もいない，電気もついていない，"
     msg = msg + "悪臭漂う部屋の片隅で・・・"
     msg = msg + "主を失ったパソコンの光だけが，"
-    msg = msg + "動かなくなった" + "@"+to_name
-    msg = msg + "を優しく照らし続けていた．"
-    msg = msg + '　' * (rand(140-msg.split(//).size+1)+1)
-    Service.primary.post(:message => msg,
-                         :replyto => opt.messages[0])
+    msg = msg + "動かなくなった" + " @"+to_name
+    msg = msg + " を優しく照らし続けていた．"
+    msg = msg + '　' * [(rand(140-msg.split(//).size+1)+1), 0].max
+    compose(opt.world, opt.messages[0], body: msg)
   end
 end


### PR DESCRIPTION
mikutter 4.0でTwitterプラグインを導入していない場合、Serviceクラスが存在しないためリプライしようとするとクラッシュするようになってしまったので、その修正です。

- mikutter 3.7以降のspell記法を利用することにしました（ `compose` ）。これによってTwitter以外でも使えるようになります。
- Twitterでは条件によっては140文字以上の投稿ができるため、本文が長すぎる場合 `String#*` に負の値を渡してしまう問題を修正しました(L20)